### PR TITLE
Get all shared instances - aka all singletons

### DIFF
--- a/src/Console/Commands/PotSingletonCommand.php
+++ b/src/Console/Commands/PotSingletonCommand.php
@@ -30,7 +30,8 @@ final class PotSingletonCommand extends PotCommand
      */
     public function handle(): int
     {
-        $instances = (fn () => $this->instances)->call($this->container);
+        $instances = collect($this->container->getBindings())
+            ->filter(fn (array $binding) => $binding['shared']);
 
         $this->section('Instances');
 

--- a/src/Console/Commands/PotSingletonCommand.php
+++ b/src/Console/Commands/PotSingletonCommand.php
@@ -36,10 +36,6 @@ final class PotSingletonCommand extends PotCommand
         $this->section('Instances');
 
         foreach ($instances as $abstract => $instance) {
-            if (isset($bindings[$abstract])) {
-                continue;
-            }
-
             $this->item($abstract, $instance);
         }
 


### PR DESCRIPTION
Added an additional command for listing only singletons, and extracted common methods to a `PotCommand` which both commands now extend.